### PR TITLE
Jobs now use placeholders to prevent duplicate jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ chromedriver
 log.txt
 screenshots
 !tests/*
+tools

--- a/core/Hubs/Hubs.py
+++ b/core/Hubs/Hubs.py
@@ -416,6 +416,13 @@ def submitPregenWithData(doPregen, user, hub, track, numLabels, coverageUrl, txn
             problemTxn.abort()
             continue
 
+        placeHolders = job.getJobModelSumPlaceholder()
+
+        modelSummaries = db.ModelSummaries(user, hub, track['track'], problem['chrom'],
+                                           problem['chromStart'])
+
+        modelSummaries.put(placeHolders, txn=problemTxn)
+
         problemTxn.commit()
 
 

--- a/core/Jobs/Jobs.py
+++ b/core/Jobs/Jobs.py
@@ -635,7 +635,6 @@ def jobsStats(data, txn=None):
     jobs = []
     for job in db.Job.all(txn=txn):
         numJobs = numJobs + 1
-        jobs.append(job.__dict__())
         status = job.status.lower()
 
         if status == 'new':
@@ -650,6 +649,9 @@ def jobsStats(data, txn=None):
             for task in job.tasks.values():
                 if task['status'].lower() == 'done':
                     times.append(float(task['totalTime']))
+
+        if status != 'done':
+            jobs.append(job.__dict__())
 
     if len(times) == 0:
         avgTime = 0
@@ -698,6 +700,9 @@ def spawnJobs(data, txn=None):
 
     while current is not None:
         key, job = current
+
+        if job.status.lower() == 'error':
+            continue
 
         contigKey = job.user, job.hub, job.track, job.problem['chrom'], str(job.problem['chromStart'])
 

--- a/core/Jobs/Jobs.py
+++ b/core/Jobs/Jobs.py
@@ -701,10 +701,6 @@ def spawnJobs(data, txn=None):
     while current is not None:
         key, job = current
 
-        if job.status.lower() == 'error':
-            current = jobCursor.next()
-            continue
-
         contigKey = job.user, job.hub, job.track, job.problem['chrom'], str(job.problem['chromStart'])
 
         if contigKey in jobsByContig:
@@ -760,6 +756,9 @@ def getPotentialJobs(contigJobs, txn=None):
     # Checks all regions where models have already potentially been computed
     for key in contigJobs:
         modelSums = db.ModelSummaries(*key).get(txn=txn)
+
+        if len(modelSums.index) < 1:
+            continue
 
         nonZeroRegions = modelSums[modelSums['regions'] > 0]
 

--- a/core/Jobs/Jobs.py
+++ b/core/Jobs/Jobs.py
@@ -121,7 +121,6 @@ class Job(metaclass=JobType):
         while current is not None:
             key, job = current
             if self.equals(job):
-                print(job.debugDict())
                 cursor.close()
                 return True
             current = cursor.next()
@@ -240,30 +239,6 @@ class Job(metaclass=JobType):
                   'status': self.status,
                   'id': self.id,
                   'iteration': self.iteration,
-                  'tasks': self.tasks,
-                  'trackUrl': self.trackUrl,
-                  'priority': int(self.priority)}
-
-        try:
-            output['lastModified'] = self.lastModified
-        except AttributeError:
-            pass
-
-        if self.status.lower() == 'done':
-            try:
-                output['time'] = self.time
-            except AttributeError:
-                pass
-
-        return output
-
-    def debugDict(self):
-        output = {'user': self.user,
-                  'hub': self.hub,
-                  'track': self.track,
-                  'problem': self.problem,
-                  'jobType': self.jobType,
-                  'status': self.status,
                   'tasks': self.tasks,
                   'trackUrl': self.trackUrl,
                   'priority': int(self.priority)}
@@ -759,14 +734,10 @@ def spawnJobs(data, txn=None):
 
     jobsLeft = cfg.maxJobsToSpawn - len(jobs)
 
-    print('jobsLeft', jobsLeft)
-
     if jobsLeft > 0:
         resOut = getResolutionJobs(jobsLeft, txn=None)
         if resOut is not None and len(resOut) > 0:
             jobs.extend(resOut)
-
-    print('numJobs', len(jobs))
 
     for job in jobs:
         job.putNewJob(txn=txn, checkExists=False)
@@ -803,7 +774,6 @@ def getPotentialJobs(contigJobs, txn=None):
                 continue
 
             if not jobToAppend.checkIfExists(txn=txn):
-                print(jobToAppend.debugDict())
                 output.append(jobToAppend)
             continue
 
@@ -898,7 +868,7 @@ def jobToRefine(key, modelSums, txn=None):
                                      problem['chromStart']).get(txn=txn)
 
             if iteration < 5:
-                return submitGridSearch(problem, data, minPenalty, maxPenalty, regions, txn=txn)
+                return submitGridSearch(problem, data, minPenalty, maxPenalty, regions)
         return
 
     elif numMinErrors == 1:
@@ -953,7 +923,7 @@ def submitOOMJob(problem, data, penalty, jobType, regions):
                           regions)
 
 
-def submitGridSearch(problem, data, minPenalty, maxPenalty, regions, num=cfg.gridSearchSize, txn=None):
+def submitGridSearch(problem, data, minPenalty, maxPenalty, regions, num=cfg.gridSearchSize):
     minPenalty = float(minPenalty)
     maxPenalty = float(maxPenalty)
     penalties = np.linspace(minPenalty, maxPenalty, num + 2).tolist()[1:-1]

--- a/core/Jobs/Jobs.py
+++ b/core/Jobs/Jobs.py
@@ -702,6 +702,7 @@ def spawnJobs(data, txn=None):
         key, job = current
 
         if job.status.lower() == 'error':
+            current = jobCursor.next()
             continue
 
         contigKey = job.user, job.hub, job.track, job.problem['chrom'], str(job.problem['chromStart'])

--- a/core/Jobs/Jobs.py
+++ b/core/Jobs/Jobs.py
@@ -723,8 +723,6 @@ def spawnJobs(data, txn=None):
 
     jobs = getPotentialJobs(jobsByContig, txn=txn)
 
-    print('jobsLen', len(jobs))
-
     # If not enough jobs, check for predict jobs
     jobsLeft = cfg.maxJobsToSpawn - len(jobs)
 
@@ -741,7 +739,6 @@ def spawnJobs(data, txn=None):
             jobs.extend(resOut)
 
     for job in jobs:
-        print(job)
         job.putNewJob(txn=txn)
 
 

--- a/core/Models/Models.py
+++ b/core/Models/Models.py
@@ -238,14 +238,13 @@ def putModel(data, txn=None):
 def calculateModelLabelError(modelDf, labels, problem, penalty):
     labels = labels[labels['annotation'] != 'unknown']
     peaks = modelDf[modelDf['annotation'] == 'peak']
+    labelsIsInProblem = labels.apply(db.checkInBounds, axis=1,
+                                     args=(problem['chrom'], problem['chromStart'], problem['chromEnd']))
     numPeaks = len(peaks.index)
-    numLabels = len(labels.index)
+    numLabels = len(labelsIsInProblem.index)
 
     if numLabels < 1:
         return getErrorSeries(penalty, numPeaks, numLabels)
-
-    labelsIsInProblem = labels.apply(db.checkInBounds, axis=1,
-                                     args=(problem['chrom'], problem['chromStart'], problem['chromEnd']))
 
     if numPeaks < 1:
         return getErrorSeries(penalty, numPeaks, numLabels)

--- a/core/Models/Models.py
+++ b/core/Models/Models.py
@@ -62,6 +62,15 @@ def getModels(data, txn=None):
                 output = output.append(minErrorModel, ignore_index=True)
                 continue
 
+        # Remove processing models from ones which can be displayed
+        modelSummaries = modelSummaries[modelSummaries['errors'] >= 0]
+
+        if len(modelSummaries.index) < 1:
+            altout = generateAltModel(data, problem, txn=txn)
+            if isinstance(altout, pd.DataFrame):
+                output = output.append(altout, ignore_index=True)
+            continue
+
         nonZeroRegions = modelSummaries[modelSummaries['regions'] > 0]
 
         if len(nonZeroRegions.index) < 1:
@@ -193,11 +202,18 @@ def updateAllModelLabels(data, labels, txn):
                                  problem,
                                  peakSegDiskPrePenalties,
                                  len(labels.index))
-            if out is not None:
-                out.putNewJob(txn=modelTxn)
-                modelTxn.commit()
-            else:
-                modelTxn.abort()
+
+            out.putNewJob(txn=modelTxn)
+            placeHolders = out.getJobModelSumPlaceholder()
+            modelSummaries.put(placeHolders, txn=modelTxn)
+            modelTxn.commit()
+            continue
+
+        processedSums = modelsums[modelsums['errors'] >= 0]
+
+        # Models being processed but not yet available
+        if len(processedSums.index) < 1:
+            modelTxn.commit()
             continue
 
         newSum = modelsums.apply(modelSumLabelUpdate, axis=1, args=(labels, data, problem, modelTxn))
@@ -243,10 +259,7 @@ def calculateModelLabelError(modelDf, labels, problem, penalty):
     numPeaks = len(peaks.index)
     numLabels = len(labelsIsInProblem.index)
 
-    if numLabels < 1:
-        return getErrorSeries(penalty, numPeaks, numLabels)
-
-    if numPeaks < 1:
+    if numPeaks < 1 > numLabels:
         return getErrorSeries(penalty, numPeaks, numLabels)
 
     labelsInProblem = labels[labelsIsInProblem]
@@ -273,7 +286,7 @@ def calculateModelLabelError(modelDf, labels, problem, penalty):
 
 def getErrorSeries(penalty, numPeaks, regions=0):
     return pd.Series({'regions': regions, 'fp': 0, 'possible_fp': 0, 'fn': 0, 'possible_fn': 0,
-                      'errors': 0, 'penalty': penalty, 'numPeaks': numPeaks})
+                      'errors': -1, 'penalty': penalty, 'numPeaks': numPeaks})
 
 
 # TODO: This could be better (learning a penalty based on PeakSegDisk Models?)

--- a/core/util/PLdb.py
+++ b/core/util/PLdb.py
@@ -163,6 +163,10 @@ class Job(db.Resource):
     pass
 
 
+class DoneJob(Job):
+    pass
+
+
 class JobCursor(db.Cursor):
     def __init__(self, cursor, parent):
         super().__init__(cursor.cursor, parent)
@@ -263,9 +267,6 @@ class Features(db.Resource):
 
     def make_details(self):
         return {}
-
-    def convert(self, value, *args):
-        return db.Resource.convert(self, value[0])
 
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2021.1
 requests==2.25.1
 scipy==1.6.3
 selenium==3.141.0
-simpleBDB==1.1.19
+simpleBDB==1.1.20
 six==1.16.0
 soupsieve==2.2.1
 toml==0.10.2

--- a/tests/Slurm/test_SlurmRunner.py
+++ b/tests/Slurm/test_SlurmRunner.py
@@ -41,15 +41,11 @@ class PeakLearnerTests(Base.PeakLearnerTestBase):
             job = db.Job('2').get(txn=txn, write=True)
             txn.commit()
 
-            if job.status != 'New':
+            # Empty dict default return for get when the job doesn't actually exist
+            if isinstance(job, dict):
                 break
             runTask()
 
-        txn = db.getTxn()
-        job = db.Job('2').get(txn=txn)
-        txn.commit()
-
-        assert job.status == 'Done'
 
     def tearDown(self):
         super().tearDown()

--- a/tests/test_PeakLearner.py
+++ b/tests/test_PeakLearner.py
@@ -459,7 +459,6 @@ class PeakLearnerTests(Base.PeakLearnerTestBase):
         params = {'ref': problemWithNoLabels['chrom'],
                   'start': problemWithNoLabels['chromStart'], 'end': problemWithNoLabels['chromEnd']}
 
-
         modelOut = self.testapp.get(modelUrl, params=params, headers={'Accept': 'application/json'})
 
         assert modelOut.status_code == 200

--- a/uploadScreenshots.sh
+++ b/uploadScreenshots.sh
@@ -2,4 +2,4 @@
 
 tar -cvf screenshots.tar.gz screenshots/
 
-curl --upload-file screenshots.tar.gz https://transfer.sh screenshots.tar.gz
+curl --upload-file screenshots.tar.gz https://transfer.sh/screenshots.tar.gz


### PR DESCRIPTION
Jobs are now placing placeholder modelSums/features to prevent duplicate jobs from being added.

Jobs won't be spawned if there are already placeholder values there.

Done jobs are also now removed from the Job DB and moved to a DoneJob db.