### PR TITLE
Errors involving permissions should now error out correctly

### DIFF
--- a/core/Hubs/routes.py
+++ b/core/Hubs/routes.py
@@ -7,7 +7,7 @@ from core.Labels import Labels
 from core.util import PLConfig as cfg
 
 from pydantic import BaseModel
-from fastapi import APIRouter, Request, Form
+from fastapi import APIRouter, Request, Form, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
@@ -144,6 +144,9 @@ async def setPublic(request: Request, user: str, hub: str):
 
     returnVal = Hubs.makeHubPublic(data)
 
+    if isinstance(returnVal, Response):
+        return Response
+
     # See other status code, should redirect to GET response instead of POST
     return RedirectResponse('/myHubs', status_code=304)
 
@@ -174,7 +177,9 @@ def addTrack(request: Request, user: str, hub: str, category: str = Form(...), t
     hubName = hub
     owner = user
 
-    Hubs.addTrack(owner, hubName, userEmail, category, track, url)
+    out = Hubs.addTrack(owner, hubName, userEmail, category, track, url)
+    if isinstance(out, Response):
+        return out
 
     return RedirectResponse('/myHubs', status_code=302)
 
@@ -202,7 +207,9 @@ async def removeTrack(request: Request, user: str, hub: str, trackName: str = Fo
     else:
         userEmail = authUser['email']
 
-    Hubs.removeTrack(user, hub, userEmail, trackName)
+    out = Hubs.removeTrack(user, hub, userEmail, trackName)
+    if out is not None:
+        return out
 
     return RedirectResponse('/myHubs', status_code=302)
 

--- a/core/Permissions/Permissions.py
+++ b/core/Permissions/Permissions.py
@@ -1,6 +1,7 @@
 from simpleBDB import retry, txnAbortOnError, AbortTXNException
 from core.util import PLdb as db
 from fastapi.security import OAuth2PasswordBearer
+from fastapi import Response
 
 
 defaultPerms = {'Label': True, 'Track': False, 'Hub': False, 'Moderator': False}
@@ -122,8 +123,11 @@ def addUserToHub(request, owner, hubName, newUser, txn=None):
     permDb = db.Permission(owner, hubName)
     perms = permDb.get(txn=txn, write=True)
 
+    if perms is None:
+        return Response(status_code=404)
+
     if not perms.hasPermission(authUser, 'Hub'):
-        return
+        return Response(status_code=401)
 
     perms.users[newUser] = defaultPerms.copy()
 

--- a/core/Permissions/routes.py
+++ b/core/Permissions/routes.py
@@ -66,7 +66,9 @@ async def addUser(request: Request, user: str, hub: str, userEmail: str = Form(.
         current hub is seamless.
     """
 
-    Permissions.addUserToHub(request, user, hub, userEmail)
+    out = Permissions.addUserToHub(request, user, hub, userEmail)
+    if out is not None:
+        return out
 
     return RedirectResponse('/myHubs', status_code=302)
 
@@ -84,6 +86,8 @@ async def removeUser(request: Request, user: str, hub: str, coUserName: str = Fo
         current hub is seamless.
     """
 
-    Hubs.removeUserFromHub(request, user, hub, coUserName)
+    out = Hubs.removeUserFromHub(request, user, hub, coUserName)
+    if out is not None:
+        return out
 
     return RedirectResponse('/myHubs', status_code=302)

--- a/core/util/PLdb.py
+++ b/core/util/PLdb.py
@@ -349,8 +349,6 @@ class Permission(db.Resource):
             return db.Resource.toStorable(data)
         return None
 
-    def make_details(self):
-        return Permissions.defaultPerms
     pass
 
 

--- a/tests/core/test_Labels.py
+++ b/tests/core/test_Labels.py
@@ -25,6 +25,8 @@ class PeakLearnerJobsTests(Base.PeakLearnerTestBase):
     track = 'aorta_ENCFF115HTK'
     hubURL = os.path.join(user, hub)
     labelURL = os.path.join(hubURL, 'labels')
+    badHubUrl = os.path.join('fake', hub)
+    badLabelURL = os.path.join(badHubUrl, 'labels')
     rangeArgs = {'ref': 'chr1', 'start': 0, 'end': 120000000}
 
     def setUp(self):
@@ -38,6 +40,12 @@ class PeakLearnerJobsTests(Base.PeakLearnerTestBase):
 
     def test_addHubLabel(self):
         label = {'ref': 'chr1', 'start': 15250059, 'end': 15251519, 'label': 'peakStart'}
+
+        # Test label for non existant route
+        out = self.testapp.put(self.badLabelURL, json=label)
+
+        assert out.status_code == 404
+
         out = self.testapp.put(self.labelURL, json=label)
 
         assert out.status_code == 200
@@ -83,6 +91,10 @@ class PeakLearnerJobsTests(Base.PeakLearnerTestBase):
 
         assert len(out.json()) != 0
 
+        # Test bad hub
+        out = self.testapp.get(self.badLabelURL, params={'contig': True}, headers={'Accept': 'application/json'})
+
+        assert out.status_code == 404
 
 
 


### PR DESCRIPTION
Fixes #92 
Commands using permissions should now return the correct status code for a nonexistent hub as well as for when a user doesn't have the permissions, instead of throwing an exception like before.