### PR TITLE
Remove check for processed sums, handle that in model get phase

### DIFF
--- a/core/Models/Models.py
+++ b/core/Models/Models.py
@@ -228,13 +228,6 @@ def updateAllModelLabels(data, labels, txn):
             modelTxn.commit()
             continue
 
-        processedSums = modelsums[modelsums['errors'] >= 0]
-
-        # Models being processed but not yet available
-        if len(processedSums.index) < 1:
-            modelTxn.commit()
-            continue
-
         newSum = modelsums.apply(modelSumLabelUpdate, axis=1, args=(labels, data, problem, modelTxn))
 
         try:


### PR DESCRIPTION
Fixes #72

I'm pretty sure this one was already fixed as I haven't been able to duplicate it. This should ensure it and make sure modelSums with an error are checked to see if an error can be calculated. This is also not the easiest thing to test, as it requires the DB to be in a certain state to accomplish this. I need to come up with some tooling which can delete everything in the DB not required for a specific test.